### PR TITLE
flake: add overlay for all packages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -257,5 +257,13 @@
       formatter = forAllSystems ({ pkgs, ... }: pkgs.nixfmt-tree);
 
       checks = self.packages;
+
+      overlays.default =
+        with nixpkgs.lib;
+        (composeManyExtensions (
+          mapAttrsToList (input: _: inputs.${input}.overlays.default) (
+            filterAttrs (name: _: name != "self" && name != "nixpkgs" && name != "systems") inputs
+          )
+        ));
     };
 }


### PR DESCRIPTION
Should allow for adding more hypr things in the future and not needing to update this overlay. Tell me if it's dumb.

I did test this on my dotfiles and it seems to override the packages as expected, currently it fails building due to hyprland plugins not building against v0.54.0.