### PR TITLE
aquamarine: Bump to v0.14.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,16 +16,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1763922789,
-        "narHash": "sha256-XnkWjCpeXfip9tqYdL0b0zzBDjq+dgdISvEdSVGdVyA=",
+        "lastModified": 1785170094,
+        "narHash": "sha256-YMh/llUAd7ENxYQozt8oZEUcD9jlZHIKYDVbOeVkh8Y=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "a20a0e67a33b6848378a91b871b89588d3a12573",
+        "rev": "a79fb21b2e2a82dd061a6d071802bcf38bd5c383",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
-        "ref": "v0.10.0",
+        "ref": "v0.14.0",
         "repo": "aquamarine",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     systems.url = "github:nix-systems/default-linux";
 
     aquamarine = {
-      url = "github:hyprwm/aquamarine/v0.10.0";
+      url = "github:hyprwm/aquamarine/v0.14.0";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.systems.follows = "systems";
       inputs.hyprutils.follows = "hyprutils";


### PR DESCRIPTION
Currently, the script is not updating tags for aquamarine (and
hyprwayland-scanner), so this commit is doing a manual update of that
input.

I've tried using a GitHub token (via `gh`) with the update script, but it still
isn't detecting new tags for aquamarine.

Without this commit, builds fail on NixOS 26.05, due to Aquamarine being out of
date.
