### PR TITLE
hyprwayland-scanner: Bump to v0.4.6

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -839,16 +839,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1751897909,
-        "narHash": "sha256-FnhBENxihITZldThvbO7883PdXC/2dzW4eiNvtoV5Ao=",
+        "lastModified": 1777159683,
+        "narHash": "sha256-Jxixw6wZphUp+nHYxOKUYSckL17QMBx2d5Zp0rJHr1g=",
         "owner": "hyprwm",
         "repo": "hyprwayland-scanner",
-        "rev": "fcca0c61f988a9d092cbb33e906775014c61579d",
+        "rev": "b8632713a6beaf28b56f2a7b0ab2fb7088dbb404",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
-        "ref": "v0.4.5",
+        "ref": "v0.4.6",
         "repo": "hyprwayland-scanner",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -180,7 +180,7 @@
     };
 
     hyprwayland-scanner = {
-      url = "github:hyprwm/hyprwayland-scanner/v0.4.5";
+      url = "github:hyprwm/hyprwayland-scanner/v0.4.6";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.systems.follows = "systems";
     };


### PR DESCRIPTION
Currently, the script is not updating tags for hyprwayland-scanner (and
aquamarine), so this commit is doing a manual update of that input.

I've tried using a GitHub token (via gh) with the update script, but it still
isn't detecting new tags for hyprwayland-scanner.

Without this commit, builds don't seem to fail on NixOS 26.05, but I felt it
would be good to keep hyprwayland-scanner up to date, regardless.
