### PR TITLE
fix: separate flake input urls from input overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Nix
 /.direnv/
+/result
+/result-man
 
 # Update Script
 flake.nix.backup*

--- a/flake.lock
+++ b/flake.lock
@@ -177,16 +177,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1785170029,
-        "narHash": "sha256-8CKDx282HhxlD1pwXPnC4uK29Abn1Jsnh7LgPzeIXxI=",
+        "lastModified": 1785939201,
+        "narHash": "sha256-IptZjFf/bE9lv8SQLef4Wmn3KOs3BwchYr6aFcCJ9NI=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "5c9377c15f85c50648f35ca5a213754f95b93ca0",
+        "rev": "efb50993780079460b0cbed1363e2166a2de1d9f",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
-        "ref": "v0.56.1",
+        "ref": "v0.56.2",
         "repo": "hyprland",
         "type": "github"
       }
@@ -651,16 +651,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1784323413,
-        "narHash": "sha256-XnAVV+H4f8Xdv0yZcSwJ5kCjLyE8fHxPeLX6a3HSrAU=",
+        "lastModified": 1786642952,
+        "narHash": "sha256-WGAG9f7YnEjAu33WWxL6kkOyZGgcpiASwdNxpkwr2AQ=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "5f03477ab3a005ff27c527486f551883535aea2f",
+        "rev": "2db328fe2b3e8b6a2eee5d17a91ff1ca4177719f",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
-        "ref": "v0.14.0",
+        "ref": "v0.14.1",
         "repo": "hyprutils",
         "type": "github"
       }
@@ -718,11 +718,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786106723,
-        "narHash": "sha256-zDSUbpoeo/9ZmD2+wXnzxoo1+uhL8vxc0b8yuYMKYq0=",
+        "lastModified": 1786599213,
+        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f13ff45afd1bb73e640eaa08a7066dbed07e3238",
+        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -30,66 +30,6 @@
         "type": "github"
       }
     },
-    "aquamarine_2": {
-      "inputs": {
-        "hyprutils": [
-          "hyprpwcenter",
-          "hyprutils"
-        ],
-        "hyprwayland-scanner": "hyprwayland-scanner",
-        "nixpkgs": [
-          "hyprpwcenter",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprpwcenter",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1770166889,
-        "narHash": "sha256-ffxABFykweSQHhSZvL2iKWKVA2rqfgw8kAHIqs1fDRQ=",
-        "owner": "hyprwm",
-        "repo": "aquamarine",
-        "rev": "35fa4a965e0fa725fe21c289703680fd75e61211",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "aquamarine",
-        "type": "github"
-      }
-    },
-    "aquamarine_3": {
-      "inputs": {
-        "hyprutils": [
-          "hyprshutdown",
-          "hyprutils"
-        ],
-        "hyprwayland-scanner": "hyprwayland-scanner_2",
-        "nixpkgs": [
-          "hyprshutdown",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprshutdown",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1772460678,
-        "narHash": "sha256-NYaWs8fYJ38IgFld0hGSdT2LEVhrgO8SiRReBjIH7YY=",
-        "owner": "hyprwm",
-        "repo": "aquamarine",
-        "rev": "5d2cb726b16ee349df443f84b64cff53221b6983",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "aquamarine",
-        "type": "github"
-      }
-    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -295,16 +235,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1785939201,
-        "narHash": "sha256-IptZjFf/bE9lv8SQLef4Wmn3KOs3BwchYr6aFcCJ9NI=",
+        "lastModified": 1785170029,
+        "narHash": "sha256-8CKDx282HhxlD1pwXPnC4uK29Abn1Jsnh7LgPzeIXxI=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "efb50993780079460b0cbed1363e2166a2de1d9f",
+        "rev": "5c9377c15f85c50648f35ca5a213754f95b93ca0",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
-        "ref": "v0.56.2",
+        "ref": "v0.56.1",
         "repo": "hyprland",
         "type": "github"
       }
@@ -614,7 +554,9 @@
     },
     "hyprpwcenter": {
       "inputs": {
-        "aquamarine": "aquamarine_2",
+        "aquamarine": [
+          "aquamarine"
+        ],
         "hyprgraphics": "hyprgraphics_2",
         "hyprtoolkit": [
           "hyprtoolkit"
@@ -646,7 +588,9 @@
     },
     "hyprshutdown": {
       "inputs": {
-        "aquamarine": "aquamarine_3",
+        "aquamarine": [
+          "aquamarine"
+        ],
         "hyprgraphics": "hyprgraphics_3",
         "hyprtoolkit": [
           "hyprtoolkit"
@@ -761,75 +705,21 @@
         ]
       },
       "locked": {
-        "lastModified": 1786642952,
-        "narHash": "sha256-WGAG9f7YnEjAu33WWxL6kkOyZGgcpiASwdNxpkwr2AQ=",
+        "lastModified": 1784323413,
+        "narHash": "sha256-XnAVV+H4f8Xdv0yZcSwJ5kCjLyE8fHxPeLX6a3HSrAU=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "2db328fe2b3e8b6a2eee5d17a91ff1ca4177719f",
+        "rev": "5f03477ab3a005ff27c527486f551883535aea2f",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
-        "ref": "v0.14.1",
+        "ref": "v0.14.0",
         "repo": "hyprutils",
         "type": "github"
       }
     },
     "hyprwayland-scanner": {
-      "inputs": {
-        "nixpkgs": [
-          "hyprpwcenter",
-          "aquamarine",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprpwcenter",
-          "aquamarine",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1751897909,
-        "narHash": "sha256-FnhBENxihITZldThvbO7883PdXC/2dzW4eiNvtoV5Ao=",
-        "owner": "hyprwm",
-        "repo": "hyprwayland-scanner",
-        "rev": "fcca0c61f988a9d092cbb33e906775014c61579d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hyprwayland-scanner",
-        "type": "github"
-      }
-    },
-    "hyprwayland-scanner_2": {
-      "inputs": {
-        "nixpkgs": [
-          "hyprshutdown",
-          "aquamarine",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprshutdown",
-          "aquamarine",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1772459835,
-        "narHash": "sha256-978jRz/y/9TKmZb/qD4lEYHCQGHpEXGqy+8X2lFZsak=",
-        "owner": "hyprwm",
-        "repo": "hyprwayland-scanner",
-        "rev": "0a692d4a645165eebd65f109146b8861e3a925e7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hyprwayland-scanner",
-        "type": "github"
-      }
-    },
-    "hyprwayland-scanner_3": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
@@ -939,7 +829,7 @@
         "hyprsunset": "hyprsunset",
         "hyprtoolkit": "hyprtoolkit",
         "hyprutils": "hyprutils",
-        "hyprwayland-scanner": "hyprwayland-scanner_3",
+        "hyprwayland-scanner": "hyprwayland-scanner",
         "hyprwire": "hyprwire",
         "nixpkgs": "nixpkgs",
         "systems": "systems",
@@ -983,16 +873,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1785359135,
-        "narHash": "sha256-sRAGZVUPgwxpx19uZwaSERa86g1AbsBUQ3SxhaRPgeg=",
+        "lastModified": 1784370585,
+        "narHash": "sha256-nzm1lwk41EzFVYC6HX7YCFnjCGJ2Ac1n7xi47ajYu8Y=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "cc8e5ef8fb2acef3db488b9a33b0c48c2a4ee204",
+        "rev": "f36f5ff9e94dc5698d6a66e5cebd8d6b2e599068",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
-        "ref": "v1.4.1",
+        "ref": "v1.4.0",
         "repo": "xdg-desktop-portal-hyprland",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -16,76 +16,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1763922789,
-        "narHash": "sha256-XnkWjCpeXfip9tqYdL0b0zzBDjq+dgdISvEdSVGdVyA=",
+        "lastModified": 1785170094,
+        "narHash": "sha256-YMh/llUAd7ENxYQozt8oZEUcD9jlZHIKYDVbOeVkh8Y=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "a20a0e67a33b6848378a91b871b89588d3a12573",
+        "rev": "a79fb21b2e2a82dd061a6d071802bcf38bd5c383",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
-        "ref": "v0.10.0",
-        "repo": "aquamarine",
-        "type": "github"
-      }
-    },
-    "aquamarine_2": {
-      "inputs": {
-        "hyprutils": [
-          "hyprpwcenter",
-          "hyprutils"
-        ],
-        "hyprwayland-scanner": "hyprwayland-scanner",
-        "nixpkgs": [
-          "hyprpwcenter",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprpwcenter",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1770166889,
-        "narHash": "sha256-ffxABFykweSQHhSZvL2iKWKVA2rqfgw8kAHIqs1fDRQ=",
-        "owner": "hyprwm",
-        "repo": "aquamarine",
-        "rev": "35fa4a965e0fa725fe21c289703680fd75e61211",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "aquamarine",
-        "type": "github"
-      }
-    },
-    "aquamarine_3": {
-      "inputs": {
-        "hyprutils": [
-          "hyprshutdown",
-          "hyprutils"
-        ],
-        "hyprwayland-scanner": "hyprwayland-scanner_2",
-        "nixpkgs": [
-          "hyprshutdown",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprshutdown",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1772460678,
-        "narHash": "sha256-NYaWs8fYJ38IgFld0hGSdT2LEVhrgO8SiRReBjIH7YY=",
-        "owner": "hyprwm",
-        "repo": "aquamarine",
-        "rev": "5d2cb726b16ee349df443f84b64cff53221b6983",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
+        "ref": "v0.14.0",
         "repo": "aquamarine",
         "type": "github"
       }
@@ -614,7 +554,9 @@
     },
     "hyprpwcenter": {
       "inputs": {
-        "aquamarine": "aquamarine_2",
+        "aquamarine": [
+          "aquamarine"
+        ],
         "hyprgraphics": "hyprgraphics_2",
         "hyprtoolkit": [
           "hyprtoolkit"
@@ -646,7 +588,9 @@
     },
     "hyprshutdown": {
       "inputs": {
-        "aquamarine": "aquamarine_3",
+        "aquamarine": [
+          "aquamarine"
+        ],
         "hyprgraphics": "hyprgraphics_3",
         "hyprtoolkit": [
           "hyprtoolkit"
@@ -778,60 +722,6 @@
     "hyprwayland-scanner": {
       "inputs": {
         "nixpkgs": [
-          "hyprpwcenter",
-          "aquamarine",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprpwcenter",
-          "aquamarine",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1751897909,
-        "narHash": "sha256-FnhBENxihITZldThvbO7883PdXC/2dzW4eiNvtoV5Ao=",
-        "owner": "hyprwm",
-        "repo": "hyprwayland-scanner",
-        "rev": "fcca0c61f988a9d092cbb33e906775014c61579d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hyprwayland-scanner",
-        "type": "github"
-      }
-    },
-    "hyprwayland-scanner_2": {
-      "inputs": {
-        "nixpkgs": [
-          "hyprshutdown",
-          "aquamarine",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprshutdown",
-          "aquamarine",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1772459835,
-        "narHash": "sha256-978jRz/y/9TKmZb/qD4lEYHCQGHpEXGqy+8X2lFZsak=",
-        "owner": "hyprwm",
-        "repo": "hyprwayland-scanner",
-        "rev": "0a692d4a645165eebd65f109146b8861e3a925e7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hyprwayland-scanner",
-        "type": "github"
-      }
-    },
-    "hyprwayland-scanner_3": {
-      "inputs": {
-        "nixpkgs": [
           "nixpkgs"
         ],
         "systems": [
@@ -839,16 +729,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1751897909,
-        "narHash": "sha256-FnhBENxihITZldThvbO7883PdXC/2dzW4eiNvtoV5Ao=",
+        "lastModified": 1777159683,
+        "narHash": "sha256-Jxixw6wZphUp+nHYxOKUYSckL17QMBx2d5Zp0rJHr1g=",
         "owner": "hyprwm",
         "repo": "hyprwayland-scanner",
-        "rev": "fcca0c61f988a9d092cbb33e906775014c61579d",
+        "rev": "b8632713a6beaf28b56f2a7b0ab2fb7088dbb404",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
-        "ref": "v0.4.5",
+        "ref": "v0.4.6",
         "repo": "hyprwayland-scanner",
         "type": "github"
       }
@@ -939,7 +829,7 @@
         "hyprsunset": "hyprsunset",
         "hyprtoolkit": "hyprtoolkit",
         "hyprutils": "hyprutils",
-        "hyprwayland-scanner": "hyprwayland-scanner_3",
+        "hyprwayland-scanner": "hyprwayland-scanner",
         "hyprwire": "hyprwire",
         "nixpkgs": "nixpkgs",
         "systems": "systems",

--- a/flake.lock
+++ b/flake.lock
@@ -100,64 +100,6 @@
         "type": "github"
       }
     },
-    "hyprgraphics_2": {
-      "inputs": {
-        "hyprutils": [
-          "hyprpwcenter",
-          "hyprutils"
-        ],
-        "nixpkgs": [
-          "hyprpwcenter",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprpwcenter",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1769284023,
-        "narHash": "sha256-xG34vwYJ79rA2wVC8KFuM8r36urJTG6/csXx7LiiSYU=",
-        "owner": "hyprwm",
-        "repo": "hyprgraphics",
-        "rev": "13c536659d46893596412d180449353a900a1d31",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hyprgraphics",
-        "type": "github"
-      }
-    },
-    "hyprgraphics_3": {
-      "inputs": {
-        "hyprutils": [
-          "hyprshutdown",
-          "hyprutils"
-        ],
-        "nixpkgs": [
-          "hyprshutdown",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprshutdown",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1772461523,
-        "narHash": "sha256-mI6A51do+hEUzeJKk9YSWfVHdI/SEEIBi2tp5Whq5mI=",
-        "owner": "hyprwm",
-        "repo": "hyprgraphics",
-        "rev": "7d63c04b4a2dd5e59ef943b4b143f46e713df804",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hyprgraphics",
-        "type": "github"
-      }
-    },
     "hypridle": {
       "inputs": {
         "hyprland-protocols": [
@@ -557,7 +499,9 @@
         "aquamarine": [
           "aquamarine"
         ],
-        "hyprgraphics": "hyprgraphics_2",
+        "hyprgraphics": [
+          "hyprgraphics"
+        ],
         "hyprtoolkit": [
           "hyprtoolkit"
         ],
@@ -591,7 +535,9 @@
         "aquamarine": [
           "aquamarine"
         ],
-        "hyprgraphics": "hyprgraphics_3",
+        "hyprgraphics": [
+          "hyprgraphics"
+        ],
         "hyprtoolkit": [
           "hyprtoolkit"
         ],

--- a/flake.lock
+++ b/flake.lock
@@ -819,16 +819,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1784370585,
-        "narHash": "sha256-nzm1lwk41EzFVYC6HX7YCFnjCGJ2Ac1n7xi47ajYu8Y=",
+        "lastModified": 1785359135,
+        "narHash": "sha256-sRAGZVUPgwxpx19uZwaSERa86g1AbsBUQ3SxhaRPgeg=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "f36f5ff9e94dc5698d6a66e5cebd8d6b2e599068",
+        "rev": "cc8e5ef8fb2acef3db488b9a33b0c48c2a4ee204",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
-        "ref": "v1.4.0",
+        "ref": "v1.4.1",
         "repo": "xdg-desktop-portal-hyprland",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,222 +5,227 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     systems.url = "github:nix-systems/default-linux";
 
-    aquamarine = {
-      url = "github:hyprwm/aquamarine/v0.14.0";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.hyprutils.follows = "hyprutils";
-      inputs.hyprwayland-scanner.follows = "hyprwayland-scanner";
+    aquamarine.url = "github:hyprwm/aquamarine/v0.14.0";
+    aquamarine.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      hyprutils.follows = "hyprutils";
+      hyprwayland-scanner.follows = "hyprwayland-scanner";
     };
 
-    hyprcursor = {
-      url = "github:hyprwm/hyprcursor/v0.1.13";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.hyprlang.follows = "hyprlang";
+    hyprcursor.url = "github:hyprwm/hyprcursor/v0.1.13";
+    hyprcursor.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      hyprlang.follows = "hyprlang";
     };
 
-    hyprgraphics = {
-      url = "github:hyprwm/hyprgraphics/v0.5.1";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.hyprutils.follows = "hyprutils";
+    hyprgraphics.url = "github:hyprwm/hyprgraphics/v0.5.1";
+    hyprgraphics.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      hyprutils.follows = "hyprutils";
     };
 
-    hypridle = {
-      url = "github:hyprwm/hypridle/v0.1.8";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.hyprland-protocols.follows = "hyprland-protocols";
-      inputs.hyprlang.follows = "hyprlang";
-      inputs.hyprutils.follows = "hyprutils";
-      inputs.hyprwayland-scanner.follows = "hyprwayland-scanner";
+    hypridle.url = "github:hyprwm/hypridle/v0.1.8";
+    hypridle.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      hyprland-protocols.follows = "hyprland-protocols";
+      hyprlang.follows = "hyprlang";
+      hyprutils.follows = "hyprutils";
+      hyprwayland-scanner.follows = "hyprwayland-scanner";
     };
 
-    hyprland = {
-      url = "github:hyprwm/hyprland/v0.56.2";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.aquamarine.follows = "aquamarine";
-      inputs.hyprcursor.follows = "hyprcursor";
-      inputs.hyprgraphics.follows = "hyprgraphics";
-      inputs.hyprland-guiutils.follows = "hyprland-guiutils";
-      inputs.hyprland-protocols.follows = "hyprland-protocols";
-      inputs.hyprlang.follows = "hyprlang";
-      inputs.hyprutils.follows = "hyprutils";
-      inputs.hyprwayland-scanner.follows = "hyprwayland-scanner";
-      inputs.hyprwire.follows = "hyprwire";
-      inputs.xdph.follows = "xdph";
+    hyprland.url = "github:hyprwm/hyprland/v0.56.1";
+    hyprland.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      aquamarine.follows = "aquamarine";
+      hyprcursor.follows = "hyprcursor";
+      hyprgraphics.follows = "hyprgraphics";
+      hyprland-guiutils.follows = "hyprland-guiutils";
+      hyprland-protocols.follows = "hyprland-protocols";
+      hyprlang.follows = "hyprlang";
+      hyprutils.follows = "hyprutils";
+      hyprwayland-scanner.follows = "hyprwayland-scanner";
+      hyprwire.follows = "hyprwire";
+      xdph.follows = "xdph";
     };
 
-    hyprland-guiutils = {
-      url = "github:hyprwm/hyprland-guiutils/v0.2.2";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.aquamarine.follows = "aquamarine";
-      inputs.hyprgraphics.follows = "hyprgraphics";
-      inputs.hyprlang.follows = "hyprlang";
-      inputs.hyprtoolkit.follows = "hyprtoolkit";
-      inputs.hyprutils.follows = "hyprutils";
-      inputs.hyprwayland-scanner.follows = "hyprwayland-scanner";
+    hyprland-guiutils.url = "github:hyprwm/hyprland-guiutils/v0.2.2";
+    hyprland-guiutils.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      aquamarine.follows = "aquamarine";
+      hyprgraphics.follows = "hyprgraphics";
+      hyprlang.follows = "hyprlang";
+      hyprtoolkit.follows = "hyprtoolkit";
+      hyprutils.follows = "hyprutils";
+      hyprwayland-scanner.follows = "hyprwayland-scanner";
     };
 
-    hyprland-protocols = {
-      url = "github:hyprwm/hyprland-protocols/v0.7.0";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
+    hyprland-protocols.url = "github:hyprwm/hyprland-protocols/v0.7.0";
+    hyprland-protocols.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
     };
 
-    hyprland-qt-support = {
-      url = "github:hyprwm/hyprland-qt-support/v0.1.0";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
+    hyprland-qt-support.url = "github:hyprwm/hyprland-qt-support/v0.1.0";
+    hyprland-qt-support.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
     };
 
-    hyprlang = {
-      url = "github:hyprwm/hyprlang/v0.6.8";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.hyprutils.follows = "hyprutils";
+    hyprlang.url = "github:hyprwm/hyprlang/v0.6.8";
+    hyprlang.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      hyprutils.follows = "hyprutils";
     };
 
-    hyprlauncher = {
-      url = "github:hyprwm/hyprlauncher/v0.1.6";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.aquamarine.follows = "aquamarine";
-      inputs.hyprgraphics.follows = "hyprgraphics";
-      inputs.hyprlang.follows = "hyprlang";
-      inputs.hyprtoolkit.follows = "hyprtoolkit";
-      inputs.hyprutils.follows = "hyprutils";
-      inputs.hyprwayland-scanner.follows = "hyprwayland-scanner";
-      inputs.hyprwire.follows = "hyprwire";
+    hyprlauncher.url = "github:hyprwm/hyprlauncher/v0.1.6";
+    hyprlauncher.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      aquamarine.follows = "aquamarine";
+      hyprgraphics.follows = "hyprgraphics";
+      hyprlang.follows = "hyprlang";
+      hyprtoolkit.follows = "hyprtoolkit";
+      hyprutils.follows = "hyprutils";
+      hyprwayland-scanner.follows = "hyprwayland-scanner";
+      hyprwire.follows = "hyprwire";
     };
 
-    hyprlock = {
-      url = "github:hyprwm/hyprlock/v0.9.6";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.hyprgraphics.follows = "hyprgraphics";
-      inputs.hyprlang.follows = "hyprlang";
-      inputs.hyprutils.follows = "hyprutils";
-      inputs.hyprwayland-scanner.follows = "hyprwayland-scanner";
+    hyprlock.url = "github:hyprwm/hyprlock/v0.9.6";
+    hyprlock.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      hyprgraphics.follows = "hyprgraphics";
+      hyprlang.follows = "hyprlang";
+      hyprutils.follows = "hyprutils";
+      hyprwayland-scanner.follows = "hyprwayland-scanner";
     };
 
-    hyprpaper = {
-      url = "github:hyprwm/hyprpaper/v0.8.4";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.aquamarine.follows = "aquamarine";
-      inputs.hyprgraphics.follows = "hyprgraphics";
-      inputs.hyprlang.follows = "hyprlang";
-      inputs.hyprtoolkit.follows = "hyprtoolkit";
-      inputs.hyprutils.follows = "hyprutils";
-      inputs.hyprwayland-scanner.follows = "hyprwayland-scanner";
-      inputs.hyprwire.follows = "hyprwire";
+    hyprpaper.url = "github:hyprwm/hyprpaper/v0.8.4";
+    hyprpaper.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      aquamarine.follows = "aquamarine";
+      hyprgraphics.follows = "hyprgraphics";
+      hyprlang.follows = "hyprlang";
+      hyprtoolkit.follows = "hyprtoolkit";
+      hyprutils.follows = "hyprutils";
+      hyprwayland-scanner.follows = "hyprwayland-scanner";
+      hyprwire.follows = "hyprwire";
     };
 
-    hyprpicker = {
-      url = "github:hyprwm/hyprpicker/v0.4.7";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.hyprutils.follows = "hyprutils";
-      inputs.hyprwayland-scanner.follows = "hyprwayland-scanner";
+    hyprpicker.url = "github:hyprwm/hyprpicker/v0.4.7";
+    hyprpicker.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      hyprutils.follows = "hyprutils";
+      hyprwayland-scanner.follows = "hyprwayland-scanner";
     };
 
-    hyprpolkitagent = {
-      url = "github:hyprwm/hyprpolkitagent/v0.1.3";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.hyprland-qt-support.follows = "hyprland-qt-support";
-      inputs.hyprutils.follows = "hyprutils";
+    hyprpolkitagent.url = "github:hyprwm/hyprpolkitagent/v0.1.3";
+    hyprpolkitagent.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      hyprland-qt-support.follows = "hyprland-qt-support";
+      hyprutils.follows = "hyprutils";
     };
 
-    hyprpwcenter = {
-      url = "github:hyprwm/hyprpwcenter/v0.1.2";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.hyprtoolkit.follows = "hyprtoolkit";
-      inputs.hyprutils.follows = "hyprutils";
+    hyprpwcenter.url = "github:hyprwm/hyprpwcenter/v0.1.2";
+    hyprpwcenter.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      aquamarine.follows = "aquamarine";
+      hyprtoolkit.follows = "hyprtoolkit";
+      hyprutils.follows = "hyprutils";
     };
 
-    hyprshutdown = {
-      url = "github:hyprwm/hyprshutdown/v0.1.1";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.hyprtoolkit.follows = "hyprtoolkit";
-      inputs.hyprutils.follows = "hyprutils";
+    hyprshutdown.url = "github:hyprwm/hyprshutdown/v0.1.1";
+    hyprshutdown.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      aquamarine.follows = "aquamarine";
+      hyprtoolkit.follows = "hyprtoolkit";
+      hyprutils.follows = "hyprutils";
     };
 
-    hyprsunset = {
-      url = "github:hyprwm/hyprsunset/v0.4.0";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.hyprland-protocols.follows = "hyprland-protocols";
-      inputs.hyprlang.follows = "hyprlang";
-      inputs.hyprutils.follows = "hyprutils";
-      inputs.hyprwayland-scanner.follows = "hyprwayland-scanner";
+    hyprsunset.url = "github:hyprwm/hyprsunset/v0.4.0";
+    hyprsunset.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      hyprland-protocols.follows = "hyprland-protocols";
+      hyprlang.follows = "hyprlang";
+      hyprutils.follows = "hyprutils";
+      hyprwayland-scanner.follows = "hyprwayland-scanner";
     };
 
-    hyprtoolkit = {
-      url = "github:hyprwm/hyprtoolkit/v0.5.4";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.aquamarine.follows = "aquamarine";
-      inputs.hyprgraphics.follows = "hyprgraphics";
-      inputs.hyprlang.follows = "hyprlang";
-      inputs.hyprutils.follows = "hyprutils";
-      inputs.hyprwayland-scanner.follows = "hyprwayland-scanner";
+    hyprtoolkit.url = "github:hyprwm/hyprtoolkit/v0.5.4";
+    hyprtoolkit.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      aquamarine.follows = "aquamarine";
+      hyprgraphics.follows = "hyprgraphics";
+      hyprlang.follows = "hyprlang";
+      hyprutils.follows = "hyprutils";
+      hyprwayland-scanner.follows = "hyprwayland-scanner";
     };
 
-    hyprutils = {
-      url = "github:hyprwm/hyprutils/v0.14.1";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
+    hyprutils.url = "github:hyprwm/hyprutils/v0.14.0";
+    hyprutils.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
     };
 
-    hyprwayland-scanner = {
-      url = "github:hyprwm/hyprwayland-scanner/v0.4.6";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
+    hyprwayland-scanner.url = "github:hyprwm/hyprwayland-scanner/v0.4.6";
+    hyprwayland-scanner.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
     };
 
-    hyprwire = {
-      url = "github:hyprwm/hyprwire/v0.3.1";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.hyprutils.follows = "hyprutils";
+    hyprwire.url = "github:hyprwm/hyprwire/v0.3.1";
+    hyprwire.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      hyprutils.follows = "hyprutils";
     };
 
-    xdph = {
-      url = "github:hyprwm/xdg-desktop-portal-hyprland/v1.4.1";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.hyprland-protocols.follows = "hyprland-protocols";
-      inputs.hyprlang.follows = "hyprlang";
-      inputs.hyprutils.follows = "hyprutils";
-      inputs.hyprwayland-scanner.follows = "hyprwayland-scanner";
+    xdph.url = "github:hyprwm/xdg-desktop-portal-hyprland/v1.4.0";
+    xdph.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      hyprland-protocols.follows = "hyprland-protocols";
+      hyprlang.follows = "hyprlang";
+      hyprutils.follows = "hyprutils";
+      hyprwayland-scanner.follows = "hyprwayland-scanner";
     };
   };
 
-  outputs = inputs @ {
-    self,
-    nixpkgs,
-    ...
-  }: let
-    systems = import inputs.systems;
-    forAllSystems = f:
-      nixpkgs.lib.genAttrs systems (
-        system:
+  outputs =
+    inputs@{
+      self,
+      nixpkgs,
+      ...
+    }:
+    let
+      systems = import inputs.systems;
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs systems (
+          system:
           f {
             inherit system;
-            pkgs = import nixpkgs {inherit system;};
+            pkgs = import nixpkgs { inherit system; };
           }
-      );
-  in {
-    packages = forAllSystems (
-      {system, ...}:
-        {
+        );
+    in
+    {
+      packages = forAllSystems (
+        { system, ... }: {
           default = self.packages.${system}.hyprland;
           inherit (inputs.aquamarine.packages.${system}) aquamarine;
           inherit (inputs.hyprcursor.packages.${system}) hyprcursor;
@@ -245,19 +250,18 @@
           inherit (inputs.hyprwire.packages.${system}) hyprwire;
           inherit (inputs.xdph.packages.${system}) xdg-desktop-portal-hyprland;
         }
-    );
+      );
 
-    formatter = forAllSystems ({pkgs, ...}: pkgs.nixfmt-tree);
+      formatter = forAllSystems ({ pkgs, ... }: pkgs.nixfmt-tree);
 
-    checks = self.packages;
+      checks = self.packages;
 
-    overlays.default =
-      with nixpkgs.lib;
-      (composeManyExtensions (
-        mapAttrsToList (input: _: inputs.${input}.overlays.default) (
-          filterAttrs (name: _: name != "self" && name != "nixpkgs" && name != "systems") inputs
-        )
-      ));
+      overlays.default =
+        with nixpkgs.lib;
+        (composeManyExtensions (
+          mapAttrsToList (input: _: inputs.${input}.overlays.default) (
+            filterAttrs (name: _: name != "self" && name != "nixpkgs" && name != "systems") inputs
+          )
+        ));
     };
-
 }

--- a/flake.nix
+++ b/flake.nix
@@ -5,222 +5,227 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     systems.url = "github:nix-systems/default-linux";
 
-    aquamarine = {
-      url = "github:hyprwm/aquamarine/v0.10.0";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.hyprutils.follows = "hyprutils";
-      inputs.hyprwayland-scanner.follows = "hyprwayland-scanner";
+    aquamarine.url = "github:hyprwm/aquamarine/v0.14.0";
+    aquamarine.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      hyprutils.follows = "hyprutils";
+      hyprwayland-scanner.follows = "hyprwayland-scanner";
     };
 
-    hyprcursor = {
-      url = "github:hyprwm/hyprcursor/v0.1.13";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.hyprlang.follows = "hyprlang";
+    hyprcursor.url = "github:hyprwm/hyprcursor/v0.1.13";
+    hyprcursor.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      hyprlang.follows = "hyprlang";
     };
 
-    hyprgraphics = {
-      url = "github:hyprwm/hyprgraphics/v0.5.1";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.hyprutils.follows = "hyprutils";
+    hyprgraphics.url = "github:hyprwm/hyprgraphics/v0.5.1";
+    hyprgraphics.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      hyprutils.follows = "hyprutils";
     };
 
-    hypridle = {
-      url = "github:hyprwm/hypridle/v0.1.8";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.hyprland-protocols.follows = "hyprland-protocols";
-      inputs.hyprlang.follows = "hyprlang";
-      inputs.hyprutils.follows = "hyprutils";
-      inputs.hyprwayland-scanner.follows = "hyprwayland-scanner";
+    hypridle.url = "github:hyprwm/hypridle/v0.1.8";
+    hypridle.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      hyprland-protocols.follows = "hyprland-protocols";
+      hyprlang.follows = "hyprlang";
+      hyprutils.follows = "hyprutils";
+      hyprwayland-scanner.follows = "hyprwayland-scanner";
     };
 
-    hyprland = {
-      url = "github:hyprwm/hyprland/v0.56.1";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.aquamarine.follows = "aquamarine";
-      inputs.hyprcursor.follows = "hyprcursor";
-      inputs.hyprgraphics.follows = "hyprgraphics";
-      inputs.hyprland-guiutils.follows = "hyprland-guiutils";
-      inputs.hyprland-protocols.follows = "hyprland-protocols";
-      inputs.hyprlang.follows = "hyprlang";
-      inputs.hyprutils.follows = "hyprutils";
-      inputs.hyprwayland-scanner.follows = "hyprwayland-scanner";
-      inputs.hyprwire.follows = "hyprwire";
-      inputs.xdph.follows = "xdph";
+    hyprland.url = "github:hyprwm/hyprland/v0.56.1";
+    hyprland.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      aquamarine.follows = "aquamarine";
+      hyprcursor.follows = "hyprcursor";
+      hyprgraphics.follows = "hyprgraphics";
+      hyprland-guiutils.follows = "hyprland-guiutils";
+      hyprland-protocols.follows = "hyprland-protocols";
+      hyprlang.follows = "hyprlang";
+      hyprutils.follows = "hyprutils";
+      hyprwayland-scanner.follows = "hyprwayland-scanner";
+      hyprwire.follows = "hyprwire";
+      xdph.follows = "xdph";
     };
 
-    hyprland-guiutils = {
-      url = "github:hyprwm/hyprland-guiutils/v0.2.2";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.aquamarine.follows = "aquamarine";
-      inputs.hyprgraphics.follows = "hyprgraphics";
-      inputs.hyprlang.follows = "hyprlang";
-      inputs.hyprtoolkit.follows = "hyprtoolkit";
-      inputs.hyprutils.follows = "hyprutils";
-      inputs.hyprwayland-scanner.follows = "hyprwayland-scanner";
+    hyprland-guiutils.url = "github:hyprwm/hyprland-guiutils/v0.2.2";
+    hyprland-guiutils.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      aquamarine.follows = "aquamarine";
+      hyprgraphics.follows = "hyprgraphics";
+      hyprlang.follows = "hyprlang";
+      hyprtoolkit.follows = "hyprtoolkit";
+      hyprutils.follows = "hyprutils";
+      hyprwayland-scanner.follows = "hyprwayland-scanner";
     };
 
-    hyprland-protocols = {
-      url = "github:hyprwm/hyprland-protocols/v0.7.0";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
+    hyprland-protocols.url = "github:hyprwm/hyprland-protocols/v0.7.0";
+    hyprland-protocols.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
     };
 
-    hyprland-qt-support = {
-      url = "github:hyprwm/hyprland-qt-support/v0.1.0";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
+    hyprland-qt-support.url = "github:hyprwm/hyprland-qt-support/v0.1.0";
+    hyprland-qt-support.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
     };
 
-    hyprlang = {
-      url = "github:hyprwm/hyprlang/v0.6.8";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.hyprutils.follows = "hyprutils";
+    hyprlang.url = "github:hyprwm/hyprlang/v0.6.8";
+    hyprlang.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      hyprutils.follows = "hyprutils";
     };
 
-    hyprlauncher = {
-      url = "github:hyprwm/hyprlauncher/v0.1.6";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.aquamarine.follows = "aquamarine";
-      inputs.hyprgraphics.follows = "hyprgraphics";
-      inputs.hyprlang.follows = "hyprlang";
-      inputs.hyprtoolkit.follows = "hyprtoolkit";
-      inputs.hyprutils.follows = "hyprutils";
-      inputs.hyprwayland-scanner.follows = "hyprwayland-scanner";
-      inputs.hyprwire.follows = "hyprwire";
+    hyprlauncher.url = "github:hyprwm/hyprlauncher/v0.1.6";
+    hyprlauncher.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      aquamarine.follows = "aquamarine";
+      hyprgraphics.follows = "hyprgraphics";
+      hyprlang.follows = "hyprlang";
+      hyprtoolkit.follows = "hyprtoolkit";
+      hyprutils.follows = "hyprutils";
+      hyprwayland-scanner.follows = "hyprwayland-scanner";
+      hyprwire.follows = "hyprwire";
     };
 
-    hyprlock = {
-      url = "github:hyprwm/hyprlock/v0.9.6";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.hyprgraphics.follows = "hyprgraphics";
-      inputs.hyprlang.follows = "hyprlang";
-      inputs.hyprutils.follows = "hyprutils";
-      inputs.hyprwayland-scanner.follows = "hyprwayland-scanner";
+    hyprlock.url = "github:hyprwm/hyprlock/v0.9.6";
+    hyprlock.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      hyprgraphics.follows = "hyprgraphics";
+      hyprlang.follows = "hyprlang";
+      hyprutils.follows = "hyprutils";
+      hyprwayland-scanner.follows = "hyprwayland-scanner";
     };
 
-    hyprpaper = {
-      url = "github:hyprwm/hyprpaper/v0.8.4";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.aquamarine.follows = "aquamarine";
-      inputs.hyprgraphics.follows = "hyprgraphics";
-      inputs.hyprlang.follows = "hyprlang";
-      inputs.hyprtoolkit.follows = "hyprtoolkit";
-      inputs.hyprutils.follows = "hyprutils";
-      inputs.hyprwayland-scanner.follows = "hyprwayland-scanner";
-      inputs.hyprwire.follows = "hyprwire";
+    hyprpaper.url = "github:hyprwm/hyprpaper/v0.8.4";
+    hyprpaper.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      aquamarine.follows = "aquamarine";
+      hyprgraphics.follows = "hyprgraphics";
+      hyprlang.follows = "hyprlang";
+      hyprtoolkit.follows = "hyprtoolkit";
+      hyprutils.follows = "hyprutils";
+      hyprwayland-scanner.follows = "hyprwayland-scanner";
+      hyprwire.follows = "hyprwire";
     };
 
-    hyprpicker = {
-      url = "github:hyprwm/hyprpicker/v0.4.7";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.hyprutils.follows = "hyprutils";
-      inputs.hyprwayland-scanner.follows = "hyprwayland-scanner";
+    hyprpicker.url = "github:hyprwm/hyprpicker/v0.4.7";
+    hyprpicker.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      hyprutils.follows = "hyprutils";
+      hyprwayland-scanner.follows = "hyprwayland-scanner";
     };
 
-    hyprpolkitagent = {
-      url = "github:hyprwm/hyprpolkitagent/v0.1.3";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.hyprland-qt-support.follows = "hyprland-qt-support";
-      inputs.hyprutils.follows = "hyprutils";
+    hyprpolkitagent.url = "github:hyprwm/hyprpolkitagent/v0.1.3";
+    hyprpolkitagent.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      hyprland-qt-support.follows = "hyprland-qt-support";
+      hyprutils.follows = "hyprutils";
     };
 
-    hyprpwcenter = {
-      url = "github:hyprwm/hyprpwcenter/v0.1.2";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.hyprtoolkit.follows = "hyprtoolkit";
-      inputs.hyprutils.follows = "hyprutils";
+    hyprpwcenter.url = "github:hyprwm/hyprpwcenter/v0.1.2";
+    hyprpwcenter.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      aquamarine.follows = "aquamarine";
+      hyprtoolkit.follows = "hyprtoolkit";
+      hyprutils.follows = "hyprutils";
     };
 
-    hyprshutdown = {
-      url = "github:hyprwm/hyprshutdown/v0.1.1";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.hyprtoolkit.follows = "hyprtoolkit";
-      inputs.hyprutils.follows = "hyprutils";
+    hyprshutdown.url = "github:hyprwm/hyprshutdown/v0.1.1";
+    hyprshutdown.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      aquamarine.follows = "aquamarine";
+      hyprtoolkit.follows = "hyprtoolkit";
+      hyprutils.follows = "hyprutils";
     };
 
-    hyprsunset = {
-      url = "github:hyprwm/hyprsunset/v0.4.0";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.hyprland-protocols.follows = "hyprland-protocols";
-      inputs.hyprlang.follows = "hyprlang";
-      inputs.hyprutils.follows = "hyprutils";
-      inputs.hyprwayland-scanner.follows = "hyprwayland-scanner";
+    hyprsunset.url = "github:hyprwm/hyprsunset/v0.4.0";
+    hyprsunset.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      hyprland-protocols.follows = "hyprland-protocols";
+      hyprlang.follows = "hyprlang";
+      hyprutils.follows = "hyprutils";
+      hyprwayland-scanner.follows = "hyprwayland-scanner";
     };
 
-    hyprtoolkit = {
-      url = "github:hyprwm/hyprtoolkit/v0.5.4";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.aquamarine.follows = "aquamarine";
-      inputs.hyprgraphics.follows = "hyprgraphics";
-      inputs.hyprlang.follows = "hyprlang";
-      inputs.hyprutils.follows = "hyprutils";
-      inputs.hyprwayland-scanner.follows = "hyprwayland-scanner";
+    hyprtoolkit.url = "github:hyprwm/hyprtoolkit/v0.5.4";
+    hyprtoolkit.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      aquamarine.follows = "aquamarine";
+      hyprgraphics.follows = "hyprgraphics";
+      hyprlang.follows = "hyprlang";
+      hyprutils.follows = "hyprutils";
+      hyprwayland-scanner.follows = "hyprwayland-scanner";
     };
 
-    hyprutils = {
-      url = "github:hyprwm/hyprutils/v0.14.0";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
+    hyprutils.url = "github:hyprwm/hyprutils/v0.14.0";
+    hyprutils.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
     };
 
-    hyprwayland-scanner = {
-      url = "github:hyprwm/hyprwayland-scanner/v0.4.5";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
+    hyprwayland-scanner.url = "github:hyprwm/hyprwayland-scanner/v0.4.6";
+    hyprwayland-scanner.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
     };
 
-    hyprwire = {
-      url = "github:hyprwm/hyprwire/v0.3.1";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.hyprutils.follows = "hyprutils";
+    hyprwire.url = "github:hyprwm/hyprwire/v0.3.1";
+    hyprwire.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      hyprutils.follows = "hyprutils";
     };
 
-    xdph = {
-      url = "github:hyprwm/xdg-desktop-portal-hyprland/v1.4.0";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
-      inputs.hyprland-protocols.follows = "hyprland-protocols";
-      inputs.hyprlang.follows = "hyprlang";
-      inputs.hyprutils.follows = "hyprutils";
-      inputs.hyprwayland-scanner.follows = "hyprwayland-scanner";
+    xdph.url = "github:hyprwm/xdg-desktop-portal-hyprland/v1.4.0";
+    xdph.inputs = {
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
+      hyprland-protocols.follows = "hyprland-protocols";
+      hyprlang.follows = "hyprlang";
+      hyprutils.follows = "hyprutils";
+      hyprwayland-scanner.follows = "hyprwayland-scanner";
     };
   };
 
-  outputs = inputs @ {
-    self,
-    nixpkgs,
-    ...
-  }: let
-    systems = import inputs.systems;
-    forAllSystems = f:
-      nixpkgs.lib.genAttrs systems (
-        system:
+  outputs =
+    inputs@{
+      self,
+      nixpkgs,
+      ...
+    }:
+    let
+      systems = import inputs.systems;
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs systems (
+          system:
           f {
             inherit system;
-            pkgs = import nixpkgs {inherit system;};
+            pkgs = import nixpkgs { inherit system; };
           }
-      );
-  in {
-    packages = forAllSystems (
-      {system, ...}:
-        {
+        );
+    in
+    {
+      packages = forAllSystems (
+        { system, ... }: {
           default = self.packages.${system}.hyprland;
           inherit (inputs.aquamarine.packages.${system}) aquamarine;
           inherit (inputs.hyprcursor.packages.${system}) hyprcursor;
@@ -245,19 +250,18 @@
           inherit (inputs.hyprwire.packages.${system}) hyprwire;
           inherit (inputs.xdph.packages.${system}) xdg-desktop-portal-hyprland;
         }
-    );
+      );
 
-    formatter = forAllSystems ({pkgs, ...}: pkgs.nixfmt-tree);
+      formatter = forAllSystems ({ pkgs, ... }: pkgs.nixfmt-tree);
 
-    checks = self.packages;
+      checks = self.packages;
 
-    overlays.default =
-      with nixpkgs.lib;
-      (composeManyExtensions (
-        mapAttrsToList (input: _: inputs.${input}.overlays.default) (
-          filterAttrs (name: _: name != "self" && name != "nixpkgs" && name != "systems") inputs
-        )
-      ));
+      overlays.default =
+        with nixpkgs.lib;
+        (composeManyExtensions (
+          mapAttrsToList (input: _: inputs.${input}.overlays.default) (
+            filterAttrs (name: _: name != "self" && name != "nixpkgs" && name != "systems") inputs
+          )
+        ));
     };
-
 }

--- a/flake.nix
+++ b/flake.nix
@@ -223,7 +223,7 @@
       );
   in {
     packages = forAllSystems (
-      {system, ...}: {
+      {system, ...}: rec {
         default = self.packages.${system}.hyprland;
         inherit (inputs.aquamarine.packages.${system}) aquamarine;
         inherit (inputs.hyprcursor.packages.${system}) hyprcursor;
@@ -246,7 +246,9 @@
         inherit (inputs.hyprutils.packages.${system}) hyprutils;
         inherit (inputs.hyprwayland-scanner.packages.${system}) hyprwayland-scanner;
         inherit (inputs.hyprwire.packages.${system}) hyprwire;
-        inherit (inputs.xdph.packages.${system}) xdg-desktop-portal-hyprland;
+        xdg-desktop-portal-hyprland = inputs.xdph.packages.${system}.xdg-desktop-portal-hyprland.override {
+          inherit hyprland hyprland-protocols hyprlang hyprutils hyprwayland-scanner;
+        };
       }
     );
 

--- a/flake.nix
+++ b/flake.nix
@@ -196,7 +196,7 @@
       hyprutils.follows = "hyprutils";
     };
 
-    xdph.url = "github:hyprwm/xdg-desktop-portal-hyprland/v1.4.0";
+    xdph.url = "github:hyprwm/xdg-desktop-portal-hyprland/v1.4.1";
     xdph.inputs = {
       nixpkgs.follows = "nixpkgs";
       systems.follows = "systems";

--- a/flake.nix
+++ b/flake.nix
@@ -207,59 +207,73 @@
     };
   };
 
-  outputs = inputs @ {
-    self,
-    nixpkgs,
-    ...
-  }: let
-    systems = import inputs.systems;
-    forAllSystems = f:
-      nixpkgs.lib.genAttrs systems (
-        system:
+  outputs =
+    inputs@{
+      self,
+      nixpkgs,
+      ...
+    }:
+    let
+      systems = import inputs.systems;
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs systems (
+          system:
           f {
             inherit system;
-            pkgs = import nixpkgs {inherit system;};
+            pkgs = import nixpkgs {
+              inherit system;
+              overlays = [ self.overlays.default ];
+            };
           }
+        );
+    in
+    {
+      packages = forAllSystems (
+        {
+          system,
+          pkgs,
+          ...
+        }:
+        {
+          default = pkgs.hyprland;
+          inherit (pkgs)
+            aquamarine
+            hyprcursor
+            hyprgraphics
+            hypridle
+            hyprland-guiutils
+            hyprland
+            hyprland-protocols
+            hyprland-qt-support
+            hyprlang
+            hyprlauncher
+            hyprlock
+            hyprpaper
+            hyprpicker
+            hyprpolkitagent
+            hyprpwcenter
+            hyprshutdown
+            hyprsunset
+            hyprtoolkit
+            hyprutils
+            hyprwayland-scanner
+            hyprwire
+            xdg-desktop-portal-hyprland
+            ;
+        }
       );
-  in {
-    packages = forAllSystems (
-      {system, ...}: rec {
-        default = self.packages.${system}.hyprland;
-        inherit (inputs.aquamarine.packages.${system}) aquamarine;
-        inherit (inputs.hyprcursor.packages.${system}) hyprcursor;
-        inherit (inputs.hyprgraphics.packages.${system}) hyprgraphics;
-        inherit (inputs.hypridle.packages.${system}) hypridle;
-        inherit (inputs.hyprland-guiutils.packages.${system}) hyprland-guiutils;
-        inherit (inputs.hyprland.packages.${system}) hyprland;
-        inherit (inputs.hyprland-protocols.packages.${system}) hyprland-protocols;
-        inherit (inputs.hyprland-qt-support.packages.${system}) hyprland-qt-support;
-        inherit (inputs.hyprlang.packages.${system}) hyprlang;
-        inherit (inputs.hyprlauncher.packages.${system}) hyprlauncher;
-        inherit (inputs.hyprlock.packages.${system}) hyprlock;
-        inherit (inputs.hyprpaper.packages.${system}) hyprpaper;
-        inherit (inputs.hyprpicker.packages.${system}) hyprpicker;
-        inherit (inputs.hyprpolkitagent.packages.${system}) hyprpolkitagent;
-        inherit (inputs.hyprpwcenter.packages.${system}) hyprpwcenter;
-        inherit (inputs.hyprshutdown.packages.${system}) hyprshutdown;
-        inherit (inputs.hyprsunset.packages.${system}) hyprsunset;
-        inherit (inputs.hyprtoolkit.packages.${system}) hyprtoolkit;
-        inherit (inputs.hyprutils.packages.${system}) hyprutils;
-        inherit (inputs.hyprwayland-scanner.packages.${system}) hyprwayland-scanner;
-        inherit (inputs.hyprwire.packages.${system}) hyprwire;
-        xdg-desktop-portal-hyprland = inputs.xdph.packages.${system}.xdg-desktop-portal-hyprland.override {
-          inherit hyprland hyprland-protocols hyprlang hyprutils hyprwayland-scanner;
-        };
-      }
-    );
 
-    formatter = forAllSystems ({pkgs, ...}: pkgs.nixfmt-tree);
+      formatter = forAllSystems ({ pkgs, ... }: pkgs.nixfmt-tree);
 
-    checks = self.packages;
+      checks = self.packages;
 
-    overlays.default = with nixpkgs.lib; (composeManyExtensions (
-      mapAttrsToList (input: _: inputs.${input}.overlays.default) (
-        filterAttrs (name: _: name != "self" && name != "nixpkgs" && name != "systems") inputs
-      )
-    ));
-  };
+      overlays.default =
+        with nixpkgs.lib;
+        (composeManyExtensions (
+          mapAttrsToList (input: _: inputs.${input}.overlays.default) (
+            filterAttrs (name: _: name != "self" && name != "nixpkgs" && name != "systems") inputs
+          )
+        ));
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -141,6 +141,7 @@
       nixpkgs.follows = "nixpkgs";
       systems.follows = "systems";
       aquamarine.follows = "aquamarine";
+      hyprgraphics.follows = "hyprgraphics";
       hyprtoolkit.follows = "hyprtoolkit";
       hyprutils.follows = "hyprutils";
     };
@@ -150,6 +151,7 @@
       nixpkgs.follows = "nixpkgs";
       systems.follows = "systems";
       aquamarine.follows = "aquamarine";
+      hyprgraphics.follows = "hyprgraphics";
       hyprtoolkit.follows = "hyprtoolkit";
       hyprutils.follows = "hyprutils";
     };
@@ -205,63 +207,57 @@
     };
   };
 
-  outputs =
-    inputs@{
-      self,
-      nixpkgs,
-      ...
-    }:
-    let
-      systems = import inputs.systems;
-      forAllSystems =
-        f:
-        nixpkgs.lib.genAttrs systems (
-          system:
+  outputs = inputs @ {
+    self,
+    nixpkgs,
+    ...
+  }: let
+    systems = import inputs.systems;
+    forAllSystems = f:
+      nixpkgs.lib.genAttrs systems (
+        system:
           f {
             inherit system;
-            pkgs = import nixpkgs { inherit system; };
+            pkgs = import nixpkgs {inherit system;};
           }
-        );
-    in
-    {
-      packages = forAllSystems (
-        { system, ... }: {
-          default = self.packages.${system}.hyprland;
-          inherit (inputs.aquamarine.packages.${system}) aquamarine;
-          inherit (inputs.hyprcursor.packages.${system}) hyprcursor;
-          inherit (inputs.hyprgraphics.packages.${system}) hyprgraphics;
-          inherit (inputs.hypridle.packages.${system}) hypridle;
-          inherit (inputs.hyprland-guiutils.packages.${system}) hyprland-guiutils;
-          inherit (inputs.hyprland.packages.${system}) hyprland;
-          inherit (inputs.hyprland-protocols.packages.${system}) hyprland-protocols;
-          inherit (inputs.hyprland-qt-support.packages.${system}) hyprland-qt-support;
-          inherit (inputs.hyprlang.packages.${system}) hyprlang;
-          inherit (inputs.hyprlauncher.packages.${system}) hyprlauncher;
-          inherit (inputs.hyprlock.packages.${system}) hyprlock;
-          inherit (inputs.hyprpaper.packages.${system}) hyprpaper;
-          inherit (inputs.hyprpicker.packages.${system}) hyprpicker;
-          inherit (inputs.hyprpolkitagent.packages.${system}) hyprpolkitagent;
-          inherit (inputs.hyprpwcenter.packages.${system}) hyprpwcenter;
-          inherit (inputs.hyprshutdown.packages.${system}) hyprshutdown;
-          inherit (inputs.hyprsunset.packages.${system}) hyprsunset;
-          inherit (inputs.hyprtoolkit.packages.${system}) hyprtoolkit;
-          inherit (inputs.hyprutils.packages.${system}) hyprutils;
-          inherit (inputs.hyprwayland-scanner.packages.${system}) hyprwayland-scanner;
-          inherit (inputs.hyprwire.packages.${system}) hyprwire;
-          inherit (inputs.xdph.packages.${system}) xdg-desktop-portal-hyprland;
-        }
       );
+  in {
+    packages = forAllSystems (
+      {system, ...}: {
+        default = self.packages.${system}.hyprland;
+        inherit (inputs.aquamarine.packages.${system}) aquamarine;
+        inherit (inputs.hyprcursor.packages.${system}) hyprcursor;
+        inherit (inputs.hyprgraphics.packages.${system}) hyprgraphics;
+        inherit (inputs.hypridle.packages.${system}) hypridle;
+        inherit (inputs.hyprland-guiutils.packages.${system}) hyprland-guiutils;
+        inherit (inputs.hyprland.packages.${system}) hyprland;
+        inherit (inputs.hyprland-protocols.packages.${system}) hyprland-protocols;
+        inherit (inputs.hyprland-qt-support.packages.${system}) hyprland-qt-support;
+        inherit (inputs.hyprlang.packages.${system}) hyprlang;
+        inherit (inputs.hyprlauncher.packages.${system}) hyprlauncher;
+        inherit (inputs.hyprlock.packages.${system}) hyprlock;
+        inherit (inputs.hyprpaper.packages.${system}) hyprpaper;
+        inherit (inputs.hyprpicker.packages.${system}) hyprpicker;
+        inherit (inputs.hyprpolkitagent.packages.${system}) hyprpolkitagent;
+        inherit (inputs.hyprpwcenter.packages.${system}) hyprpwcenter;
+        inherit (inputs.hyprshutdown.packages.${system}) hyprshutdown;
+        inherit (inputs.hyprsunset.packages.${system}) hyprsunset;
+        inherit (inputs.hyprtoolkit.packages.${system}) hyprtoolkit;
+        inherit (inputs.hyprutils.packages.${system}) hyprutils;
+        inherit (inputs.hyprwayland-scanner.packages.${system}) hyprwayland-scanner;
+        inherit (inputs.hyprwire.packages.${system}) hyprwire;
+        inherit (inputs.xdph.packages.${system}) xdg-desktop-portal-hyprland;
+      }
+    );
 
-      formatter = forAllSystems ({ pkgs, ... }: pkgs.nixfmt-tree);
+    formatter = forAllSystems ({pkgs, ...}: pkgs.nixfmt-tree);
 
-      checks = self.packages;
+    checks = self.packages;
 
-      overlays.default =
-        with nixpkgs.lib;
-        (composeManyExtensions (
-          mapAttrsToList (input: _: inputs.${input}.overlays.default) (
-            filterAttrs (name: _: name != "self" && name != "nixpkgs" && name != "systems") inputs
-          )
-        ));
-    };
+    overlays.default = with nixpkgs.lib; (composeManyExtensions (
+      mapAttrsToList (input: _: inputs.${input}.overlays.default) (
+        filterAttrs (name: _: name != "self" && name != "nixpkgs" && name != "systems") inputs
+      )
+    ));
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
       hyprwayland-scanner.follows = "hyprwayland-scanner";
     };
 
-    hyprland.url = "github:hyprwm/hyprland/v0.56.1";
+    hyprland.url = "github:hyprwm/hyprland/v0.56.2";
     hyprland.inputs = {
       nixpkgs.follows = "nixpkgs";
       systems.follows = "systems";
@@ -177,7 +177,7 @@
       hyprwayland-scanner.follows = "hyprwayland-scanner";
     };
 
-    hyprutils.url = "github:hyprwm/hyprutils/v0.14.0";
+    hyprutils.url = "github:hyprwm/hyprutils/v0.14.1";
     hyprutils.inputs = {
       nixpkgs.follows = "nixpkgs";
       systems.follows = "systems";

--- a/update.py
+++ b/update.py
@@ -158,8 +158,8 @@ def current_version(flake_lock: dict[str, Any], input_name: str) -> str | None:
 def parse_hypr_inputs(flake_nix_content: str) -> dict[str, str]:
     """Extract hyprwm inputs from flake.nix content."""
     pattern = re.compile(
-        r"([A-Za-z0-9_-]+)\s*=\s*\{.*?url\s*=\s*\"github:hyprwm/([^/]+)/([^\"]+)\".*?\}",
-        re.DOTALL,
+        r'^\s*([A-Za-z0-9_-]+)\.url\s*=\s*"github:hyprwm/([^/\"]+)/([^\"]+)"',
+        re.MULTILINE,
     )
 
     inputs: dict[str, str] = {}
@@ -177,11 +177,13 @@ def update_flake_nix_url(
 ) -> str:
     """Update a URL in flake.nix for a specific input."""
     escaped_name = re.escape(input_name)
+    escaped_repo = re.escape(repo_name)
     prefix = (
-        rf'(\s+{escaped_name}\s*=\s*\{{\s+url\s*=\s*)"github:hyprwm/{repo_name}/[^"]+"'
+        rf'(^\s*{escaped_name}\.url\s*=\s*)'
+        rf'"github:hyprwm/{escaped_repo}/[^"]+"'
     )
     replacement = rf'\1"github:hyprwm/{repo_name}/{new_version}"'
-    return re.sub(prefix, replacement, content)
+    return re.sub(prefix, replacement, content, flags=re.MULTILINE)
 
 
 def create_backup(path: Path) -> Path | None:


### PR DESCRIPTION
You may not like this approach, but the underlying issue was the the *first* input (in this case `aquamarine`) was getting skipped by the update script because the regex (somehow) returned the `input_name` as `"inputs"`. I simplified the regex by following (admittedly slightly non-Nix idiomatic) structure in flake.nix:

```nix
inputs = {
  <input name>.url = <github url>;
  <input name>.inputs = <input overrides>;
};
```

As a result, `aquamarine` is now on the latest version 0.14.0

Fyi, I ran `nix fmt` which accounts for the remainder of the formatting changes in flake.nix.

Closes #5 